### PR TITLE
Fixing type issues

### DIFF
--- a/cwl/classify_tumor.cwl
+++ b/cwl/classify_tumor.cwl
@@ -17,7 +17,7 @@ inputs:
           ${
             if (self.nameext == '.mrxs') {
               return {
-              class: "File",
+              class: "Directory",
               location: self.location.match(/.*\//)[0] + "/" + self.nameroot,
               basename: self.nameroot};
             }
@@ -56,4 +56,4 @@ outputs:
     type: File
     outputBinding:
       glob: '$(inputs.src.basename).zip'
-      outputEval: ${self[0].basename=inputs.label + '.zip'; return self;}
+      outputEval: ${self[0].basename=inputs.label + '.zip'; return self[0];}

--- a/cwl/extract_tissue.cwl
+++ b/cwl/extract_tissue.cwl
@@ -18,7 +18,7 @@ inputs:
           ${
             if (self.nameext == '.mrxs') {
               return {
-              class: "File",
+              class: "Directory",
               location: self.location.match(/.*\//)[0] + "/" + self.nameroot,
               basename: self.nameroot};
             }
@@ -56,4 +56,4 @@ outputs:
     type: File
     outputBinding:
       glob: '$(inputs.src.basename).zip'
-      outputEval: ${self[0].basename=inputs.label + '.zip'; return self;}
+      outputEval: ${self[0].basename=inputs.label + '.zip'; return self[0];}

--- a/cwl/predictions.cwl
+++ b/cwl/predictions.cwl
@@ -12,7 +12,7 @@ inputs:
           ${
             if (self.nameext == '.mrxs') {
               return {
-              class: "File",
+              class: "Directory",
               location: self.location.match(/.*\//)[0] + "/" + self.nameroot,
               basename: self.nameroot};
             }


### PR DESCRIPTION
There are some typing issues in the current CWL workflow:
 - In all the three CWL files, the `self.nameroot` secondary file is a `Directory`, but it is declared as a `File`
 - The `outputEval` expression in both `extract_tissue.cwl` and `classify_tumor.cwl` return an object of type `File[]`, but the output is declared as `File`.